### PR TITLE
--recent feature added with updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,28 @@
 
 ## Features
 
-- Recursively discover and process files in a repository.
-- Generates a clear, easy-to-read directory tree showing the organization of all included files.
-- Filter files based on include/exclude patterns.
-- Automatically skip binary files and large files.
-- Retrieve Git information (commit, branch, author, date) if the directory is a Git repository.
-- Generate Markdown, JSON, or YAML output.
-- Estimate token count for LLM input.
-- Handle single files or multiple repositories at once.
-- Optional truncation of large files to avoid overwhelming output.
+### **File Discovery & Processing**
+- **Recursive file discovery** - Automatically finds and processes all files in a repository
+- **Smart file filtering** - Skip binary files, large files, and unwanted directories
+- **Multiple repository support** - Handle single files or multiple repositories at once
+
+### **Directory Structure**
+- **Visual tree representation** - Generates clear, easy-to-read directory trees
+- **Organized file listing** - Shows the complete organization of all included files
+
+### **Advanced Filtering**
+- **Pattern-based filtering** - Include/exclude files using glob patterns (`*.py`, `*.js`, etc.)
+- **Recent changes filter** - Show only files modified in the last 7 days with `--recent` flag
+- **File size limits** - Optional truncation of large files to avoid overwhelming output
+
+### **Git Integration**
+- **Repository metadata** - Retrieve commit hash, branch, author, and date information
+- **Git-aware processing** - Automatically detects and processes Git repositories
+
+### **Output Formats & Analysis**
+- **Multiple output formats** - Generate Markdown, JSON, or YAML output
+- **Token estimation** - Estimate token count for LLM input optimization
+- **Summary statistics** - File counts, line counts, and other useful metrics
 
 ---
 
@@ -79,6 +92,7 @@ share-my-repo [OPTIONS] [PATHS...]
 | `--max-file-size` | Maximum file size in bytes (default: `16384`). Larger files are truncated. |
 | `--format` | Output format: `markdown` (default), `json`, `yaml`. |
 | `--tokens` | Show estimated token count for LLM input. |
+| `-r, --recent` | Include only files modified in the last 7 days. Shows modification dates in output. |
 
 ## Examples
 
@@ -104,6 +118,22 @@ share-my-repo . --include "*.py,*.js"
 ```bash
 share-my-repo . --format json --output repo.json
 ```
+
+### Show only recently modified files (last 7 days):
+```bash
+share-my-repo . --recent
+```
+
+### Show recent changes and save to file:
+```bash
+share-my-repo . --recent --output recent_changes.md
+```
+
+### Combine recent filter with other options:
+```bash
+share-my-repo . --recent --include "*.py" --format json
+```
+
 ---
 
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -14,7 +14,13 @@ from main import process_repositories
 @click.option('--format', 'output_format', type=click.Choice(['markdown', 'json', 'yaml']),
               default='markdown', help='Output format')
 @click.option('--tokens', is_flag=True, help='Show estimated token count')
-def main(paths, output, version, include, exclude, max_file_size, output_format, tokens):
+@click.option(
+    "-r", "--recent",
+    is_flag=True,
+    help="Include only files modified in the last 7 days"
+)
+
+def main(paths, output, version, include, exclude, max_file_size, output_format, tokens, recent):
     """Repository Context Packager - Convert repos to LLM-friendly format"""
 
     if version:
@@ -33,7 +39,8 @@ def main(paths, output, version, include, exclude, max_file_size, output_format,
             exclude=exclude,
             max_file_size=max_file_size,
             output_format=output_format,
-            show_tokens=tokens
+            show_tokens=tokens,
+            recent=recent
         )
     except Exception as e:
         click.echo(f"Error: {e}", err=True)

--- a/src/file_processor.py
+++ b/src/file_processor.py
@@ -1,4 +1,4 @@
-import os
+import os, time    ## Adding time to handle the recent option to include only files modified in the last 7 days
 import fnmatch
 from pathlib import Path
 from typing import List, Optional, Tuple, Set
@@ -237,3 +237,17 @@ class FileProcessor:
             print(f"Error discovering files in {root_path}: {e}", file=sys.stderr)
 
         return sorted(files)
+    
+    def is_recent_file(self, file_path: Path, days: int = 7) -> bool:
+        """Check if a file was modified in the last `days` days."""
+        try:
+            last_modified = file_path.stat().st_mtime
+            return (time.time() - last_modified) <= (days * 86400)
+        except (OSError, FileNotFoundError):
+            return False
+    
+    def filter_recent_files(self, files: List[Path], days: int = 7) -> List[Path]:
+        """Filter files to include only those modified in the last `days` days."""
+        return [f for f in files if self.is_recent_file(f, days)]
+
+

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,8 @@ def process_repositories(paths: List[str],
                         exclude: Optional[str] = None,
                         max_file_size: int = 16384,
                         output_format: str = 'markdown',
-                        show_tokens: bool = False):
+                        show_tokens: bool = False,
+                        recent: bool = False):
     """Main processing function with enhanced features."""
     
     VALID_FORMATS = ['markdown', 'json', 'yaml']
@@ -41,7 +42,7 @@ def process_repositories(paths: List[str],
                 repo_info = process_single_file(path, file_processor)
             elif path.is_dir():
                 repo_info = process_directory(path, file_processor, formatter, 
-                                            include_patterns, exclude_patterns)
+                                            include_patterns, exclude_patterns, recent)
             else:
                 print(f"Error: {path} is neither a file nor a directory", file=sys.stderr)
                 continue
@@ -61,10 +62,10 @@ def process_repositories(paths: List[str],
     # Handle output
     try:
         if len(all_results) == 1:
-            final_output = formatter.format_output(all_results[0], output_format, show_tokens)
+            final_output = formatter.format_output(all_results[0], output_format, show_tokens, recent)
         else:
             combined_info = combine_repositories(all_results)
-            final_output = formatter.format_output(combined_info, output_format, show_tokens)
+            final_output = formatter.format_output(combined_info, output_format, show_tokens, recent)
         
         # Output results
         if output_file:
@@ -113,7 +114,8 @@ def process_directory(path: Path,
                      file_processor: FileProcessor, 
                      formatter: OutputFormatter,
                      include_patterns: Optional[List[str]] = None,
-                     exclude_patterns: Optional[List[str]] = None) -> Dict[str, Any]:
+                     exclude_patterns: Optional[List[str]] = None,
+                     recent: bool = False) -> Dict[str, Any]:
     """Process a directory with enhanced filtering."""
     
     # Get git information
@@ -122,6 +124,11 @@ def process_directory(path: Path,
     # Discover files with enhanced filtering
     try:
         files = file_processor.discover_files(path, include_patterns, exclude_patterns)
+        
+        # Apply recent filtering if requested
+        if recent:
+            files = file_processor.filter_recent_files(files)
+            
     except Exception as e:
         print(f"Error discovering files: {e}", file=sys.stderr)
         files = []


### PR DESCRIPTION
In this PR, I have added a new `--recent` flag that allows users to filter and display only files modified in the last 7 days, making it easier to focus on recent changes in a repository.

### Files Modified
- **`src/cli.py`** - Added `--recent` flag option and parameter passing
- **`src/main.py`** - Updated function signatures to handle recent filtering
- **`src/file_processor.py`** - Added `is_recent_file()` and `filter_recent_files()` methods
- **`src/formatter.py`** - Enhanced markdown formatter to show modification dates
- **`README.md`** - Updated documentation with new feature and examples

### Basic Usage
```bash
# Show only recent files
share-my-repo . --recent

# Save recent changes to file
share-my-repo . --recent --output recent_changes.md

# Combine with other filters
share-my-repo . --recent --include "*.py" --format json
```

### Documentation
- Table to query all the commands have been updated with `--recent` & `-r` option.
- Added feature description to README.md
- Added practical usage examples

Please let me know I could change or enhance something else with this. 
